### PR TITLE
Move request data from query string to POST body

### DIFF
--- a/lib/Email/SendGrid/Transport/REST.pm
+++ b/lib/Email/SendGrid/Transport/REST.pm
@@ -161,13 +161,22 @@ sub send
   my $self = shift;
   my $query = shift;
 
+  # Split the url and the data from the query string
+  # to make a POST request with data in the body
+  my ($url, $data) = $query =~ /^([^\?]+)\?(.*)$/;
+
   my $ua = LWP::UserAgent->new( timeout => $self->{timeout}, agent => 'sendgrid/' . $VERSION . ';perl' );
 
   if ( defined($self->{api_key}) )
   {
     $ua->default_header('Authorization' => "Bearer $self->{api_key}");
-  } 
-  my $response = $ua->get($query);
+  }
+
+  my $req = HTTP::Request->new('POST', $url);
+  $req->content_type('application/x-www-form-urlencoded');
+  $req->content($data);
+
+  my $response = $ua->request($req);
 
   return { errors => [ $response->status_line() ] } if ( !$response->is_success );
 

--- a/t/lib/Email/SendGrid/Transport/REST/Test.pm
+++ b/t/lib/Email/SendGrid/Transport/REST/Test.pm
@@ -201,18 +201,23 @@ sub send_up : Test(no_plan)
   $mm->mock('new' => sub {
     $obj = Test::MockObject->new();
     $obj->set_always('default_header' => 1);
-    $obj->mock('get' => sub { return $response } );
+    $obj->mock('request' => sub { return $response } );
     return $obj;
     });
 
-  my $query = "query";
-  my $resp = $deliv->send($query);
+  my $query = 'url?data';
+
+  my $req = HTTP::Request->new('POST', 'url');
+  $req->content_type('application/x-www-form-urlencoded');
+  $req->content('data');
+
+  my $resp  = $deliv->send($query);
 
   cmp_deeply($resp, $content, "sent");
   my ($func, $args) = $obj->next_call();
-  is($func, 'get', "made call to get");
+  is($func, 'request', "made call to request");
   shift(@$args);
-  cmp_deeply($args, [$query], " with proper args");
+  cmp_deeply($args, [$req], " with proper args");
   
   ($func, $args) = $obj->next_call();
   is($func, undef, "all lwp calls accounted for");
@@ -222,9 +227,9 @@ sub send_up : Test(no_plan)
   cmp_deeply($resp, {errors => ['403 bad error']}, "error returned" );
 
   ($func, $args) = $obj->next_call();
-  is($func, 'get', "made call to get");
+  is($func, 'request', "made call to request");
   shift(@$args);
-  cmp_deeply($args, [$query], " with proper args");
+  cmp_deeply($args, [$req], " with proper args");
   
   ($func, $args) = $obj->next_call();
   is($func, undef, "all lwp calls accounted for");
@@ -241,12 +246,17 @@ sub send_apikey : Test(no_plan)
   $mm->mock('new' => sub {
     $obj = Test::MockObject->new();
     $obj->set_always('default_header' => 1);
-    $obj->mock('get' => sub { return $response } );
+    $obj->mock('request' => sub { return $response } );
     return $obj;
     });
 
-  my $query = "query";
-  my $resp = $deliv->send($query);
+  my $query = 'url?data';
+
+  my $req = HTTP::Request->new('POST', 'url');
+  $req->content_type('application/x-www-form-urlencoded');
+  $req->content('data');
+
+  my $resp  = $deliv->send($query);
 
   cmp_deeply($resp, $content, "sent");
   my ($func, $args) = $obj->next_call();
@@ -254,10 +264,10 @@ sub send_apikey : Test(no_plan)
   shift(@$args);
   cmp_deeply($args,['Authorization','Bearer k'], " with proper api key header");
 
-  ($func, $args) = $obj->next_call();  
-  is($func, 'get', "made call to get");
+  ($func, $args) = $obj->next_call();
+  is($func, 'request', "made call to request");
   shift(@$args);
-  cmp_deeply($args, [$query], " with proper args");
+  cmp_deeply($args, [$req], " with proper args");
   
   ($func, $args) = $obj->next_call();
   is($func, undef, "all lwp calls accounted for");
@@ -272,9 +282,9 @@ sub send_apikey : Test(no_plan)
   cmp_deeply($args,['Authorization','Bearer k'], " with proper api key header");
 
   ($func, $args) = $obj->next_call();
-  is($func, 'get', "made call to get");
+  is($func, 'request', "made call to request");
   shift(@$args);
-  cmp_deeply($args, [$query], " with proper args");
+  cmp_deeply($args, [$req], " with proper args");
   
   ($func, $args) = $obj->next_call();
   is($func, undef, "all lwp calls accounted for");


### PR DESCRIPTION
Update the Email::SendGrid::Transport::Rest module to make a POST
request rather than a GET request.  With a GET request the data
is put into the query string causing large requests to receive
'414 Request-URI too large' errors from the SendGrid Server. This change
allows users of the Perl library to send emails with attachments and
large amounts of text.

The change addresses this issue:
https://github.com/sendgrid/sendgrid-perl/issues/19

File Changes:

lib/Email/SendGrid/Transport/REST.pm:
- Update the send method to split the query var on url and data
- Generate a POST request with the data in the body

t/lib/Email/SendGrid/Transport/REST/Test.pm
- Update test to check that query is being split on "?"
- Check that the send method is conrtucting a proper POST request

All tests pass running 'make test' locally.
