### PR TITLE
Removed utf8 encoding from attachment data and added test.

### DIFF
--- a/lib/Email/SendGrid/Transport/REST.pm
+++ b/lib/Email/SendGrid/Transport/REST.pm
@@ -34,7 +34,7 @@ sub new
 
   if ( !(defined($self->{username}) && defined($self->{password})) && !defined($self->{api_key}) )
   {
-    die "Must speicfy username/password or api key";
+    die "Must specify username/password or api key";
   }
 
   return $self;
@@ -140,7 +140,7 @@ sub deliver
     }
     my @path = split('/', $filename);
     my $file = $path[$#path];
-    $query .= "&files[" . uri_escape(encode('utf8', $file)) . "]=" . uri_escape(encode('utf8', $data));
+    $query .= "&files[" . uri_escape(encode('utf8', $file)) . "]=" . uri_escape($data);
   }
 
   # Other headers (currently just message-id)

--- a/t/lib/Email/SendGrid/Test.pm
+++ b/t/lib/Email/SendGrid/Test.pm
@@ -257,7 +257,7 @@ sub unicode : Test(7)
   my $mText = $parts[0]->bodyhandle->as_string();
   my $mHtml = $parts[1]->bodyhandle->as_string();
 
-  ok( $mText ne $text && decode($charset, $mText) eq $text, 'unicode text portion correctly enocded');
+  ok( $mText ne $text && decode($charset, $mText) eq $text, 'unicode text portion correctly encoded');
   ok( $mHtml ne $html && decode($charset, $mHtml) eq $html, 'unicode html portion correctly encoded');
 
   # Test unicode headers

--- a/t/lib/Email/SendGrid/Transport/REST/Test.pm
+++ b/t/lib/Email/SendGrid/Transport/REST/Test.pm
@@ -134,12 +134,13 @@ sub deliver : Test(no_plan)
   is($res, undef, 'normal delivery');
 }
 
-sub unicode : Test(8)
+sub unicode : Test(9)
 {
   my $deliv;
   my $sg;
 
   my $u = "\x{587}";
+  my $binaryAttachData = chr(0xE4);
 
   $deliv = getTransport( 'send' => sub {
     my $self = shift;
@@ -164,6 +165,7 @@ sub unicode : Test(8)
     is($p->{text}, $sg->get('text', encode => 1), "unicode text set");
     is($p->{'to[]'}, $toAddr, "unicode to addr set");
     is($p->{'toname[]'}, encode('utf-8', "$u$toName"), "unicode to name set");
+    is($p->{"files[attachment1]"}, $binaryAttachData, "attachment included");
 
     return { "message" => "success" };
   });
@@ -171,6 +173,7 @@ sub unicode : Test(8)
   $sg = getSGObject(unicode => $u);
 
   $sg->header->setCategory("$u");
+  $sg->addAttachment($binaryAttachData);
 
   my $res = $deliv->deliver($sg);
 }

--- a/t/lib/Email/SendGrid/Transport/REST/Test.pm
+++ b/t/lib/Email/SendGrid/Transport/REST/Test.pm
@@ -74,12 +74,12 @@ sub create : Test(no_plan)
   eval {
     my $trans = Email::SendGrid::Transport::REST->new( username => 'u' );
   };
-  ok($@ =~ /Must speicfy username\/password or api key at/, "only providing username generated error");
+  ok($@ =~ /Must specify username\/password or api key at/, "only providing username generated error");
 
   eval {
     my $trans = Email::SendGrid::Transport::REST->new( password => 'u' );
   };
-  ok($@ =~ /Must speicfy username\/password or api key at/, "only providing password generated error");
+  ok($@ =~ /Must specify username\/password or api key at/, "only providing password generated error");
 
   eval {
     my $trans = Email::SendGrid::Transport::REST->new( username => 'u', api_key => 'k' );
@@ -165,7 +165,7 @@ sub unicode : Test(9)
     is($p->{text}, $sg->get('text', encode => 1), "unicode text set");
     is($p->{'to[]'}, $toAddr, "unicode to addr set");
     is($p->{'toname[]'}, encode('utf-8', "$u$toName"), "unicode to name set");
-    is($p->{"files[attachment1]"}, $binaryAttachData, "attachment included");
+    is($p->{'files[attachment1]'}, $binaryAttachData, "binary attachment included");
 
     return { "message" => "success" };
   });


### PR DESCRIPTION
Fixed handling of binary attachment data. The UTF8 encoding is not necessary, it corrupts the data. URI escaping alone is sufficient. Added test case for same in the current unicode test sub.

